### PR TITLE
Fix: reloading page creating new conversation

### DIFF
--- a/src/app/conversation/page.tsx
+++ b/src/app/conversation/page.tsx
@@ -126,6 +126,7 @@ function ConversationContent() {
       .then((res) => res.json())
       .then(({ conversationId: convId }) => {
         setConversationId(convId)
+        window.history.replaceState(null, '', `/conversation/${convId}`)
 
         // Fire all Round 1 calls in parallel
         models.forEach((modelKey) => {


### PR DESCRIPTION
Closes #10

## Problem

When a user refreshes the page while on `/conversation?rawInput=...&augmentedPrompt=...&models=...`, the `useEffect` in `conversation/page.tsx` runs again and creates a **brand new conversation** via `POST /api/conversation`. Every refresh duplicates the conversation in the database with a new UUID.

This happens because the conversation page uses query parameters (not a stable conversation ID) in the URL. The `startedRef` guard only prevents re-runs within the same React component lifecycle — a full page reload resets it.

## Approach

After the conversation is created and we receive the `conversationId`, use `window.history.replaceState()` to silently update the URL from `/conversation?params...` to `/conversation/{conversationId}`. This:

- **Doesn't trigger navigation** — the current component stays mounted, streaming continues uninterrupted
- **Makes the URL persistent** — on page refresh, the browser hits `/conversation/[id]` which loads the existing conversation from the database
- **No new routes or API changes needed** — the `/conversation/[id]` route already works correctly

## Planned Changes

- `src/app/conversation/page.tsx`: After receiving `conversationId` from the POST response, call `window.history.replaceState(null, '', `/conversation/${convId}`)` to replace the URL. This is a one-line fix in the `.then()` handler at line ~128.

## Test Strategy

1. **Manual test**: Start a conversation from the review page → verify URL changes from `/conversation?...` to `/conversation/{id}` → refresh page → verify conversation loads from the `[id]` route instead of creating a duplicate
2. **Verify no duplicate conversations**: Check database/conversation list before and after refresh
3. **Verify streaming isn't interrupted**: Ensure the `replaceState` call doesn't interfere with in-flight model responses
4. **Verify Round 2 still works**: The `conversationId` state variable is already set before `replaceState`, so Round 2 calls should be unaffected
5. **Verify share button URL is unchanged**: It already uses `conversationId` state, not `window.location`

## Risks / Open Questions

- **Mid-stream refresh**: If a user refreshes while responses are still streaming, the `/conversation/[id]` page will show only the responses saved to the database so far. This is acceptable (and much better than creating duplicates), but some responses may be missing. A future enhancement could show a "loading" state for in-progress conversations.
- **Browser back behavior**: `replaceState` replaces the current history entry rather than pushing a new one. The user's back button will go to the review page (correct behavior) rather than back to the query-param URL.