### PR TITLE
Fix: duplicate model responses (#11)

### DIFF
--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -23,6 +23,6 @@ export async function GET() {
     email: user.email,
     subscriptionStatus: user.subscriptionStatus,
     subscriptionCurrentPeriodEnd: user.subscriptionCurrentPeriodEnd,
-    providers: keys.map(k => k.provider),
+    providers: [...new Set(keys.map(k => k.provider))],
   })
 }

--- a/src/app/conversation/page.tsx
+++ b/src/app/conversation/page.tsx
@@ -63,7 +63,7 @@ function ConversationContent() {
   const startedRef = useRef(false)
   const tts = useTTS()
 
-  const models = (searchParams.get('models') ?? '').split(',').filter(Boolean)
+  const models = [...new Set((searchParams.get('models') ?? '').split(',').filter(Boolean))]
   const essayMode = searchParams.get('essayMode') === 'true'
   const responseLength = searchParams.get('responseLength') ?? undefined
 

--- a/src/app/review/__tests__/page.test.tsx
+++ b/src/app/review/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
 
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
@@ -91,5 +91,33 @@ describe('ReviewPage', () => {
     fireEvent.click(toggle)
     fireEvent.click(screen.getByText('Run Conversation'))
     expect(hrefSpy).toHaveBeenCalledWith(expect.stringContaining('essayMode=true'))
+  })
+
+  it('deduplicates models when API returns duplicate providers', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      json: async () => ({
+        subscriptionStatus: 'inactive',
+        providers: ['openai', 'google', 'openai', 'google'],
+      }),
+    } as Response)
+
+    render(<ReviewPage />)
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith('/api/user')
+    })
+
+    // After fetch resolves, run the conversation and check the models param
+    // Wait for state to settle after the fetch
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('Run Conversation'))
+      const url = hrefSpy.mock.calls[0]?.[0] as string
+      const params = new URLSearchParams(url.split('?')[1])
+      const models = params.get('models')?.split(',') ?? []
+      // Should have no duplicates — gpt and gemini only once each
+      expect(models).toEqual([...new Set(models)])
+    })
+
+    fetchSpy.mockRestore()
   })
 })

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -49,7 +49,7 @@ function ReviewContent() {
             if (!providerToModels[config.provider]) providerToModels[config.provider] = []
             providerToModels[config.provider].push(key)
           }
-          const available = data.providers.flatMap((p: string) => providerToModels[p] || [])
+          const available = [...new Set<string>(data.providers.flatMap((p: string) => providerToModels[p] || []))]
           setAvailableModels(available)
           setSelectedModels(available)
         }


### PR DESCRIPTION
Closes #11

## Problem

Users see duplicate response cards in Round 1 (e.g., Gemini and GPT each appearing twice with different token counts). Each duplicate triggers a separate API call, wasting money and creating duplicate database records.

## Root Cause

The `/api/user` endpoint returns `providers: keys.map(k => k.provider)` without deduplication. While the API key storage handler (`POST /api/keys`) does `delete` then `insert` to prevent duplicates, there is no unique constraint on `(userId, provider)` in the `userApiKeys` table, so race conditions or legacy data can produce duplicate provider entries.

The duplicate providers cascade through:
1. **`/api/user`** — returns `['openai', 'google', 'openai', 'google', 'xai']`
2. **Review page** — `data.providers.flatMap(p => providerToModels[p])` amplifies into `['gpt', 'gemini', 'gpt', 'gemini', 'grok']`
3. **URL params** — `models=gpt,gemini,gpt,gemini,grok`
4. **Conversation page** — `models.forEach(callModel)` fires 5 API calls instead of 3
5. **UI** — `models.map()` renders 5 response cards

## Approach

Fix at the source and add defensive deduplication at each consumer.

## Planned Changes

- `src/app/api/user/route.ts`: Deduplicate the `providers` array using `[...new Set(...)]` before returning
- `src/app/review/page.tsx`: Deduplicate the `available` models array after `flatMap` (defensive)
- `src/app/conversation/page.tsx`: Deduplicate the `models` array parsed from URL params (defensive)

## Test Strategy

- Add/update unit tests verifying deduplication at each layer
- Verify existing tests still pass
- Manual verification: with BYOK keys, only one response card per model should appear

## Risks / Open Questions

- The `userApiKeys` table lacks a unique constraint on `(userId, provider)`. A DB migration to add one would be the most robust fix but is out of scope for this PR — the application-level deduplication is sufficient.
- The shared conversation view (`/conversation/[id]`) may show duplicate responses for conversations already affected by this bug in the DB. Cleaning up existing duplicate DB records could be a follow-up.