### PR TITLE
fix: model responses do not display until page refresh

### DIFF
--- a/src/app/conversation/page.tsx
+++ b/src/app/conversation/page.tsx
@@ -61,6 +61,7 @@ function ConversationContent() {
   const [topic, setTopic] = useState('')
   const [error, setError] = useState<string | null>(null)
   const startedRef = useRef(false)
+  const modelsRef = useRef<string[]>([])
   const tts = useTTS()
 
   const models = [...new Set((searchParams.get('models') ?? '').split(',').filter(Boolean))]
@@ -112,6 +113,8 @@ function ConversationContent() {
 
     if (!augmentedPrompt || models.length === 0) return
 
+    modelsRef.current = models
+
     // Initialize round 1 loading states
     const initialStates: Record<string, ModelState> = {}
     models.forEach((m) => { initialStates[m] = { loading: true, error: null, response: null } })
@@ -155,10 +158,10 @@ function ConversationContent() {
     setRound2Started(true)
 
     const initialStates: Record<string, ModelState> = {}
-    models.forEach((m) => { initialStates[m] = { loading: true, error: null, response: null } })
+    modelsRef.current.forEach((m) => { initialStates[m] = { loading: true, error: null, response: null } })
     setRound2States(initialStates)
 
-    models.forEach((modelKey) => {
+    modelsRef.current.forEach((modelKey) => {
       callModel(conversationId, modelKey, 2)
         .then((response) => {
           setRound2States((prev) => ({ ...prev, [modelKey]: { loading: false, error: null, response } }))
@@ -352,7 +355,7 @@ function ConversationContent() {
             <div className="flex-1 h-px bg-border" />
           </div>
           <div className="space-y-3">
-            {models.map((modelKey) => {
+            {modelsRef.current.map((modelKey) => {
               const state = round1States[modelKey]
               if (!state) return null
               if (state.response) return <ResponseCard key={modelKey} r={state.response} />
@@ -370,7 +373,7 @@ function ConversationContent() {
             <div className="flex-1 h-px bg-border" />
           </div>
           <div className="space-y-3">
-            {models.map((modelKey) => {
+            {modelsRef.current.map((modelKey) => {
               const state = round2States[modelKey]
               if (!state) return null
               if (state.response) return <ResponseCard key={modelKey} r={state.response} />
@@ -385,7 +388,7 @@ function ConversationContent() {
         <div className="text-center py-10 animate-fade-in">
           <div className="inline-flex items-center gap-3 text-ink-muted">
             <span className="w-5 h-5 border-2 border-ink-faint/30 border-t-amber rounded-full animate-spin" />
-            Round 1 in progress... ({round1Responses.length} of {models.length} responses received)
+            Round 1 in progress... ({round1Responses.length} of {modelsRef.current.length} responses received)
           </div>
         </div>
       )}


### PR DESCRIPTION
Closes #14

## Problem

Model responses are fetched and saved to the database successfully, but they never render on screen. Users must refresh the page to see them. The workaround (refreshing) loads the `/conversation/[id]` detail page which fetches responses from the database directly.

## Root Cause

The conversation page (`/conversation/page.tsx`) derives the `models` array from URL search params on every render (line 66):

```tsx
const models = [...new Set((searchParams.get('models') ?? '').split(',').filter(Boolean))]
```

After the conversation is created, `window.history.replaceState` (line 129) changes the URL from `/conversation?models=claude,gpt,...` to `/conversation/{id}`, removing all query parameters. This causes `useSearchParams()` to return `null` for `models`, making the array empty.

The rendering code at line 355 iterates `models.map(...)` — with an empty array, no response cards are rendered, even though `round1States` contains the responses.

**Flow:**
1. Page mounts → `models = ['claude', 'gpt', ...]` from URL params ✓
2. useEffect fires API calls using `models` from closure ✓
3. `replaceState` changes URL → `models` re-derived as `[]` ✗
4. Responses arrive, update `round1States` ✓
5. Render: `models.map(...)` iterates empty array → nothing shown ✗
6. Refresh → loads `/conversation/[id]` page → fetches from DB → shows responses ✓

## Approach

Store the `models` list in a `useRef` (or `useState`) that is set once from the initial search params and never re-derived from the URL. This decouples the rendering from the URL state, so `replaceState` no longer breaks the display.

## Planned Changes

- `src/app/conversation/page.tsx`:
  - Add a `modelsRef = useRef<string[]>([])` to persist the initial models list
  - Initialize it from `searchParams` on first render (inside the guard that checks `startedRef`)
  - Replace all usages of the derived `models` variable with `modelsRef.current` for rendering and API calls
  - Keep the derived `models` only for the initial check (`models.length === 0` early return)

## Test Strategy

- Manual verification: start a conversation → responses should render in real-time without needing a refresh
- Round 2 should still work (uses the same `models` list)
- Retry button on error cards should still work
- Share button should still show the correct URL
- Refreshing after URL change should still load from DB via `/conversation/[id]`

## Risks / Open Questions

- The `essayMode` and `responseLength` params are also derived from search params but are only used inside the initial `useEffect` closure (which captures them before `replaceState`), so they are not affected by this bug. No changes needed for those.
- The `startRound2` function also uses `models` — this needs to use the ref too, otherwise Round 2 would be broken by the same issue.