### PR TITLE
multiple response from same models

### DIFF
--- a/src/app/conversation/page.tsx
+++ b/src/app/conversation/page.tsx
@@ -9,6 +9,7 @@ import { AudioPlayer } from '@/components/AudioPlayer'
 import { CopyButton } from '@/components/CopyButton'
 import { ShareButton } from '@/components/ShareButton'
 import { trackEvent } from '@/lib/analytics'
+import { baseModel } from '@/lib/models'
 
 interface ModelResponse {
   round: number
@@ -64,11 +65,12 @@ function ConversationContent() {
   const modelsRef = useRef<string[]>([])
   const tts = useTTS()
 
-  const models = [...new Set((searchParams.get('models') ?? '').split(',').filter(Boolean))]
+  const models = (searchParams.get('models') ?? '').split(',').filter(Boolean)
   const essayMode = searchParams.get('essayMode') === 'true'
   const responseLength = searchParams.get('responseLength') ?? undefined
 
-  const callModel = useCallback(async (convId: string, modelKey: string, round: number, attempt = 0): Promise<ModelResponse> => {
+  const callModel = useCallback(async (convId: string, instanceKey: string, round: number, attempt = 0): Promise<ModelResponse> => {
+    const modelKey = baseModel(instanceKey)
     const MAX_RETRIES = 1
     try {
       const res = await fetch('/api/conversation/respond', {
@@ -94,7 +96,7 @@ function ConversationContent() {
       if (attempt < MAX_RETRIES) {
         console.warn(`[callModel] Retrying ${modelKey} round ${round} (attempt ${attempt + 1}):`, err instanceof Error ? err.message : err)
         await new Promise(r => setTimeout(r, 3000))
-        return callModel(convId, modelKey, round, attempt + 1)
+        return callModel(convId, instanceKey, round, attempt + 1)
       }
       throw err
     }
@@ -115,29 +117,32 @@ function ConversationContent() {
 
     modelsRef.current = models
 
-    // Initialize round 1 loading states
+    // Initialize round 1 loading states using instance keys
     const initialStates: Record<string, ModelState> = {}
     models.forEach((m) => { initialStates[m] = { loading: true, error: null, response: null } })
     setRound1States(initialStates)
+
+    // Deduplicate base model keys for backend storage
+    const baseModels = [...new Set(models.map(baseModel))]
 
     // Create conversation, then fire parallel model calls
     fetch('/api/conversation', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ rawInput, augmentedPrompt, topicType, framework, models }),
+      body: JSON.stringify({ rawInput, augmentedPrompt, topicType, framework, models: baseModels }),
     })
       .then((res) => res.json())
       .then(({ conversationId: convId }) => {
         setConversationId(convId)
         window.history.replaceState(null, '', `/conversation/${convId}`)
 
-        // Fire all Round 1 calls in parallel
-        models.forEach((modelKey) => {
-          callModel(convId, modelKey, 1)
+        // Fire all Round 1 calls in parallel (one per instance key)
+        models.forEach((instanceKey) => {
+          callModel(convId, instanceKey, 1)
             .then((response) => {
-              setRound1States((prev) => ({ ...prev, [modelKey]: { loading: false, error: null, response } }))
+              setRound1States((prev) => ({ ...prev, [instanceKey]: { loading: false, error: null, response } }))
               trackEvent('model_response', {
-                model: modelKey,
+                model: baseModel(instanceKey),
                 round: 1,
                 input_tokens: response.usage?.inputTokens ?? 0,
                 output_tokens: response.usage?.outputTokens ?? 0,
@@ -145,7 +150,7 @@ function ConversationContent() {
               })
             })
             .catch((err) => {
-              setRound1States((prev) => ({ ...prev, [modelKey]: { loading: false, error: err.message, response: null } }))
+              setRound1States((prev) => ({ ...prev, [instanceKey]: { loading: false, error: err.message, response: null } }))
             })
         })
       })
@@ -161,12 +166,12 @@ function ConversationContent() {
     modelsRef.current.forEach((m) => { initialStates[m] = { loading: true, error: null, response: null } })
     setRound2States(initialStates)
 
-    modelsRef.current.forEach((modelKey) => {
-      callModel(conversationId, modelKey, 2)
+    modelsRef.current.forEach((instanceKey) => {
+      callModel(conversationId, instanceKey, 2)
         .then((response) => {
-          setRound2States((prev) => ({ ...prev, [modelKey]: { loading: false, error: null, response } }))
+          setRound2States((prev) => ({ ...prev, [instanceKey]: { loading: false, error: null, response } }))
           trackEvent('model_response', {
-            model: modelKey,
+            model: baseModel(instanceKey),
             round: 2,
             input_tokens: response.usage?.inputTokens ?? 0,
             output_tokens: response.usage?.outputTokens ?? 0,
@@ -174,7 +179,7 @@ function ConversationContent() {
           })
         })
         .catch((err) => {
-          setRound2States((prev) => ({ ...prev, [modelKey]: { loading: false, error: err.message, response: null } }))
+          setRound2States((prev) => ({ ...prev, [instanceKey]: { loading: false, error: err.message, response: null } }))
         })
     })
   }
@@ -233,15 +238,18 @@ function ConversationContent() {
 
   const activeKey = tts.playingKey || tts.pausedKey || tts.loadingKey
   const activeModelName = activeKey ? (() => {
-    const model = activeKey.split('-').slice(1).join('-')
-    const responses = [...Object.values(round1States), ...Object.values(round2States)]
-      .filter((s) => s.response)
-      .map((s) => s.response!)
-    const match = responses.find((r) => `${r.round}-${r.model}` === activeKey)
-    return match?.modelName ?? model
+    // TTS key format: round-instanceKey (e.g. "1-gpt:0")
+    const dashIdx = activeKey.indexOf('-')
+    const instanceKey = dashIdx >= 0 ? activeKey.slice(dashIdx + 1) : activeKey
+    const round1Match = round1States[instanceKey]?.response
+    const round2Match = round2States[instanceKey]?.response
+    const match = round1Match ?? round2Match
+    return match?.modelName ?? baseModel(instanceKey)
   })() : undefined
 
-  const ResponseCard = ({ r }: { r: ModelResponse }) => (
+  const ResponseCard = ({ r, instanceKey }: { r: ModelResponse; instanceKey: string }) => {
+    const ttsKey = `${r.round}-${instanceKey}`
+    return (
     <details open className="bg-card border border-border rounded-xl overflow-hidden animate-fade-up">
       <summary className="px-5 py-4 cursor-pointer select-none hover:bg-card-hover transition-colors flex items-center gap-3">
         <span className={`w-2 h-2 rounded-full flex-shrink-0 ${getDot(r.model, r.round)}`} />
@@ -255,8 +263,8 @@ function ConversationContent() {
         <span className="ml-auto flex items-center">
           <CopyButton content={r.content} model={r.model} />
           <SpeakerButton
-            state={getSpeakerState(`${r.round}-${r.model}`)}
-            onClick={() => tts.toggle(`${r.round}-${r.model}`, r.content, r.model, conversationId ?? undefined, r.round)}
+            state={getSpeakerState(ttsKey)}
+            onClick={() => tts.toggle(ttsKey, r.content, r.model, conversationId ?? undefined, r.round)}
             model={r.model}
           />
         </span>
@@ -287,41 +295,47 @@ function ConversationContent() {
         )}
       </div>
     </details>
-  )
+  )}
 
-  const LoadingCard = ({ modelKey, round }: { modelKey: string; round: number }) => (
-    <div className="bg-card border border-border rounded-xl overflow-hidden animate-fade-up px-5 py-4 flex items-center gap-3">
-      <span className={`w-2 h-2 rounded-full flex-shrink-0 ${getDot(modelKey, round)}`} />
-      <span className={`font-medium ${getAccent(modelKey, round)}`}>{modelKey}</span>
-      <span className="ml-auto w-4 h-4 border-2 border-ink-faint/30 border-t-amber rounded-full animate-spin" />
-    </div>
-  )
+  const LoadingCard = ({ instanceKey, round }: { instanceKey: string; round: number }) => {
+    const model = baseModel(instanceKey)
+    return (
+      <div className="bg-card border border-border rounded-xl overflow-hidden animate-fade-up px-5 py-4 flex items-center gap-3">
+        <span className={`w-2 h-2 rounded-full flex-shrink-0 ${getDot(model, round)}`} />
+        <span className={`font-medium ${getAccent(model, round)}`}>{model}</span>
+        <span className="ml-auto w-4 h-4 border-2 border-ink-faint/30 border-t-amber rounded-full animate-spin" />
+      </div>
+    )
+  }
 
-  const retryModel = (modelKey: string, round: number) => {
+  const retryModel = (instanceKey: string, round: number) => {
     const setStates = round === 1 ? setRound1States : setRound2States
-    setStates((prev) => ({ ...prev, [modelKey]: { loading: true, error: null, response: null } }))
-    callModel(conversationId!, modelKey, round)
+    setStates((prev) => ({ ...prev, [instanceKey]: { loading: true, error: null, response: null } }))
+    callModel(conversationId!, instanceKey, round)
       .then((response) => {
-        setStates((prev) => ({ ...prev, [modelKey]: { loading: false, error: null, response } }))
+        setStates((prev) => ({ ...prev, [instanceKey]: { loading: false, error: null, response } }))
       })
       .catch((err) => {
-        setStates((prev) => ({ ...prev, [modelKey]: { loading: false, error: err.message, response: null } }))
+        setStates((prev) => ({ ...prev, [instanceKey]: { loading: false, error: err.message, response: null } }))
       })
   }
 
-  const ErrorCard = ({ modelKey, message, round }: { modelKey: string; message: string; round: number }) => (
-    <div className="bg-danger/5 border border-danger/20 rounded-xl overflow-hidden animate-fade-up px-5 py-4 flex items-center gap-3">
-      <span className={`w-2 h-2 rounded-full flex-shrink-0 ${getDot(modelKey, round)}`} />
-      <span className={`font-medium ${getAccent(modelKey, round)}`}>{modelKey}</span>
-      <span className="text-danger text-sm ml-2">{message}</span>
-      <button
-        onClick={() => retryModel(modelKey, round)}
-        className="ml-auto px-3 py-1 text-xs font-medium bg-card border border-border hover:border-border-strong rounded-lg transition-colors cursor-pointer text-ink-muted hover:text-ink"
-      >
-        Retry
-      </button>
-    </div>
-  )
+  const ErrorCard = ({ instanceKey, message, round }: { instanceKey: string; message: string; round: number }) => {
+    const model = baseModel(instanceKey)
+    return (
+      <div className="bg-danger/5 border border-danger/20 rounded-xl overflow-hidden animate-fade-up px-5 py-4 flex items-center gap-3">
+        <span className={`w-2 h-2 rounded-full flex-shrink-0 ${getDot(model, round)}`} />
+        <span className={`font-medium ${getAccent(model, round)}`}>{model}</span>
+        <span className="text-danger text-sm ml-2">{message}</span>
+        <button
+          onClick={() => retryModel(instanceKey, round)}
+          className="ml-auto px-3 py-1 text-xs font-medium bg-card border border-border hover:border-border-strong rounded-lg transition-colors cursor-pointer text-ink-muted hover:text-ink"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div>
@@ -355,12 +369,12 @@ function ConversationContent() {
             <div className="flex-1 h-px bg-border" />
           </div>
           <div className="space-y-3">
-            {modelsRef.current.map((modelKey) => {
-              const state = round1States[modelKey]
+            {modelsRef.current.map((instanceKey) => {
+              const state = round1States[instanceKey]
               if (!state) return null
-              if (state.response) return <ResponseCard key={modelKey} r={state.response} />
-              if (state.error) return <ErrorCard key={modelKey} modelKey={modelKey} message={state.error} round={1} />
-              return <LoadingCard key={modelKey} modelKey={modelKey} round={1} />
+              if (state.response) return <ResponseCard key={instanceKey} r={state.response} instanceKey={instanceKey} />
+              if (state.error) return <ErrorCard key={instanceKey} instanceKey={instanceKey} message={state.error} round={1} />
+              return <LoadingCard key={instanceKey} instanceKey={instanceKey} round={1} />
             })}
           </div>
         </div>
@@ -373,12 +387,12 @@ function ConversationContent() {
             <div className="flex-1 h-px bg-border" />
           </div>
           <div className="space-y-3">
-            {modelsRef.current.map((modelKey) => {
-              const state = round2States[modelKey]
+            {modelsRef.current.map((instanceKey) => {
+              const state = round2States[instanceKey]
               if (!state) return null
-              if (state.response) return <ResponseCard key={modelKey} r={state.response} />
-              if (state.error) return <ErrorCard key={modelKey} modelKey={modelKey} message={state.error} round={2} />
-              return <LoadingCard key={modelKey} modelKey={modelKey} round={2} />
+              if (state.response) return <ResponseCard key={instanceKey} r={state.response} instanceKey={instanceKey} />
+              if (state.error) return <ErrorCard key={instanceKey} instanceKey={instanceKey} message={state.error} round={2} />
+              return <LoadingCard key={instanceKey} instanceKey={instanceKey} round={2} />
             })}
           </div>
         </div>

--- a/src/app/review/__tests__/page.test.tsx
+++ b/src/app/review/__tests__/page.test.tsx
@@ -93,6 +93,68 @@ describe('ReviewPage', () => {
     expect(hrefSpy).toHaveBeenCalledWith(expect.stringContaining('essayMode=true'))
   })
 
+  it('defaults each model count to 1 and sends instance keys', () => {
+    render(<ReviewPage />)
+    // All 4 models should default to count 1
+    for (const key of ['claude', 'gpt', 'gemini', 'grok']) {
+      expect(screen.getByTestId(`count-${key}`)).toHaveTextContent('1')
+    }
+    fireEvent.click(screen.getByText('Run Conversation'))
+    const url = hrefSpy.mock.calls[0]?.[0] as string
+    const params = new URLSearchParams(url.split('?')[1])
+    const models = params.get('models')?.split(',') ?? []
+    expect(models).toContain('claude:0')
+    expect(models).toContain('gpt:0')
+    expect(models).toContain('gemini:0')
+    expect(models).toContain('grok:0')
+  })
+
+  it('increases model count and generates multiple instance keys', () => {
+    render(<ReviewPage />)
+    // Click + for GPT twice to get count to 3
+    const increaseGpt = screen.getByLabelText('Increase GPT count')
+    fireEvent.click(increaseGpt)
+    fireEvent.click(increaseGpt)
+    expect(screen.getByTestId('count-gpt')).toHaveTextContent('3')
+
+    fireEvent.click(screen.getByText('Run Conversation'))
+    const url = hrefSpy.mock.calls[0]?.[0] as string
+    const params = new URLSearchParams(url.split('?')[1])
+    const models = params.get('models')?.split(',') ?? []
+    expect(models.filter(m => m.startsWith('gpt:'))).toHaveLength(3)
+    expect(models).toContain('gpt:0')
+    expect(models).toContain('gpt:1')
+    expect(models).toContain('gpt:2')
+  })
+
+  it('decreases model count to 0 and excludes from URL', () => {
+    render(<ReviewPage />)
+    const decreaseClaude = screen.getByLabelText('Decrease Claude count')
+    fireEvent.click(decreaseClaude)
+    expect(screen.getByTestId('count-claude')).toHaveTextContent('0')
+
+    fireEvent.click(screen.getByText('Run Conversation'))
+    const url = hrefSpy.mock.calls[0]?.[0] as string
+    const params = new URLSearchParams(url.split('?')[1])
+    const models = params.get('models')?.split(',') ?? []
+    expect(models.filter(m => m.startsWith('claude:'))).toHaveLength(0)
+  })
+
+  it('disables Run when all counts are 0', () => {
+    render(<ReviewPage />)
+    // Set all to 0
+    for (const name of ['Claude', 'GPT', 'Gemini', 'Grok']) {
+      fireEvent.click(screen.getByLabelText(`Decrease ${name} count`))
+    }
+    expect(screen.getByText('Run Conversation')).toBeDisabled()
+  })
+
+  it('shows total response count', () => {
+    render(<ReviewPage />)
+    // Default: 4 models × 1 = 4 total
+    expect(screen.getByText('4 responses total')).toBeInTheDocument()
+  })
+
   it('deduplicates models when API returns duplicate providers', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
       json: async () => ({
@@ -108,13 +170,12 @@ describe('ReviewPage', () => {
     })
 
     // After fetch resolves, run the conversation and check the models param
-    // Wait for state to settle after the fetch
     await waitFor(() => {
       fireEvent.click(screen.getByText('Run Conversation'))
       const url = hrefSpy.mock.calls[0]?.[0] as string
       const params = new URLSearchParams(url.split('?')[1])
       const models = params.get('models')?.split(',') ?? []
-      // Should have no duplicates — gpt and gemini only once each
+      // Should have no duplicates — gpt:0 and gemini:0 only
       expect(models).toEqual([...new Set(models)])
     })
 

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -34,7 +34,9 @@ function ReviewContent() {
 
   const [rawInput, setRawInput] = useState(initialRawInput)
   const [availableModels, setAvailableModels] = useState<string[]>(Object.keys(MODEL_CONFIGS))
-  const [selectedModels, setSelectedModels] = useState<string[]>(Object.keys(MODEL_CONFIGS))
+  const defaultCounts: Record<string, number> = {}
+  for (const key of Object.keys(MODEL_CONFIGS)) defaultCounts[key] = 1
+  const [modelCounts, setModelCounts] = useState<Record<string, number>>(defaultCounts)
 
   useEffect(() => {
     fetch('/api/user')
@@ -42,7 +44,9 @@ function ReviewContent() {
       .then(data => {
         if (data.subscriptionStatus === 'active') {
           setAvailableModels(Object.keys(MODEL_CONFIGS))
-          setSelectedModels(Object.keys(MODEL_CONFIGS))
+          const counts: Record<string, number> = {}
+          for (const key of Object.keys(MODEL_CONFIGS)) counts[key] = 1
+          setModelCounts(counts)
         } else if (data.providers?.length > 0) {
           const providerToModels: Record<string, string[]> = {}
           for (const [key, config] of Object.entries(MODEL_CONFIGS)) {
@@ -51,17 +55,24 @@ function ReviewContent() {
           }
           const available = [...new Set<string>(data.providers.flatMap((p: string) => providerToModels[p] || []))]
           setAvailableModels(available)
-          setSelectedModels(available)
+          const counts: Record<string, number> = {}
+          for (const key of available) counts[key] = 1
+          setModelCounts(counts)
         }
       })
       .catch(() => {})
   }, [])
 
-  const toggleModel = (key: string) => {
-    setSelectedModels((prev) =>
-      prev.includes(key) ? prev.filter((m) => m !== key) : [...prev, key]
-    )
+  const MAX_PER_MODEL = 3
+  const adjustCount = (key: string, delta: number) => {
+    setModelCounts((prev) => {
+      const current = prev[key] ?? 0
+      const next = Math.max(0, Math.min(MAX_PER_MODEL, current + delta))
+      return { ...prev, [key]: next }
+    })
   }
+
+  const totalSelected = Object.values(modelCounts).reduce((sum, n) => sum + n, 0)
 
   const augmentations: AugmentationsMap = useMemo(() => {
     try {
@@ -117,12 +128,19 @@ function ReviewContent() {
   }
 
   const handleRun = () => {
+    // Expand counts into instance keys: { gpt: 2, claude: 1 } → gpt:0,gpt:1,claude:0
+    const instanceKeys: string[] = []
+    for (const [key, count] of Object.entries(modelCounts)) {
+      for (let i = 0; i < count; i++) {
+        instanceKeys.push(`${key}:${i}`)
+      }
+    }
     const params = new URLSearchParams({
       rawInput,
       augmentedPrompt,
       topicType: selectedType,
       framework: currentFramework,
-      models: selectedModels.join(','),
+      models: instanceKeys.join(','),
       essayMode: String(essayMode),
       responseLength,
     })
@@ -174,23 +192,25 @@ function ReviewContent() {
       </div>
 
       <div className="animate-fade-up stagger-3 mb-6">
-        <p className="text-xs font-medium tracking-widest uppercase text-ink-faint mb-3">Panel</p>
+        <div className="flex items-center gap-3 mb-3">
+          <p className="text-xs font-medium tracking-widest uppercase text-ink-faint">Panel</p>
+          <span className="text-xs text-ink-faint">{totalSelected} response{totalSelected !== 1 ? 's' : ''} total</span>
+        </div>
         <div className="flex gap-2.5 flex-wrap">
           {Object.entries(MODEL_CONFIGS).map(([key, config]) => {
             const available = availableModels.includes(key)
-            const active = available && selectedModels.includes(key)
+            const count = modelCounts[key] ?? 0
+            const active = available && count > 0
             const colors = MODEL_COLORS[key] ?? { dot: 'bg-amber', activeBg: 'bg-amber-faint', activeBorder: 'border-amber/30', activeText: 'text-amber' }
             return (
-              <button
+              <div
                 key={key}
-                onClick={() => available && toggleModel(key)}
-                disabled={!available}
                 className={`inline-flex items-center gap-2.5 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 border ${
                   !available
-                    ? 'bg-cream-dark/20 border-border/50 text-ink-faint/40 cursor-not-allowed opacity-50'
+                    ? 'bg-cream-dark/20 border-border/50 text-ink-faint/40 opacity-50'
                     : active
-                      ? `${colors.activeBg} ${colors.activeBorder} ${colors.activeText} cursor-pointer`
-                      : 'bg-cream-dark/40 border-border text-ink-faint hover:text-ink-muted hover:border-border-strong cursor-pointer'
+                      ? `${colors.activeBg} ${colors.activeBorder} ${colors.activeText}`
+                      : 'bg-cream-dark/40 border-border text-ink-faint'
                 }`}
               >
                 <span className={`w-2.5 h-2.5 rounded-full transition-all duration-200 ${colors.dot} ${active ? 'opacity-100' : 'opacity-20'}`} />
@@ -198,7 +218,28 @@ function ReviewContent() {
                   <span>{config.name}</span>
                   <span className={`text-[10px] font-normal ${active ? 'opacity-60' : 'opacity-40'}`}>{config.modelId}</span>
                 </span>
-              </button>
+                {available && (
+                  <span className="inline-flex items-center gap-1 ml-1">
+                    <button
+                      aria-label={`Decrease ${config.name} count`}
+                      onClick={() => adjustCount(key, -1)}
+                      disabled={count <= 0}
+                      className="w-6 h-6 flex items-center justify-center rounded text-xs font-bold bg-card border border-border hover:border-border-strong disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer transition-colors"
+                    >
+                      −
+                    </button>
+                    <span className="w-5 text-center text-xs tabular-nums" data-testid={`count-${key}`}>{count}</span>
+                    <button
+                      aria-label={`Increase ${config.name} count`}
+                      onClick={() => adjustCount(key, 1)}
+                      disabled={count >= MAX_PER_MODEL}
+                      className="w-6 h-6 flex items-center justify-center rounded text-xs font-bold bg-card border border-border hover:border-border-strong disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer transition-colors"
+                    >
+                      +
+                    </button>
+                  </span>
+                )}
+              </div>
             )
           })}
         </div>
@@ -281,7 +322,7 @@ function ReviewContent() {
         </button>
         <button
           onClick={handleRun}
-          disabled={selectedModels.length === 0}
+          disabled={totalSelected === 0}
           className="flex-1 py-3 bg-amber text-white hover:bg-amber-light disabled:bg-cream-dark disabled:text-ink-faint rounded-xl font-medium transition-all duration-200 active:scale-[0.995]"
         >
           Run Conversation

--- a/src/lib/models.test.ts
+++ b/src/lib/models.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { MODEL_CONFIGS, getModelProvider, getDefaultModels, getSearchConfig } from './models'
+import { MODEL_CONFIGS, getModelProvider, getDefaultModels, getSearchConfig, baseModel } from './models'
 
 describe('Model Configuration', () => {
   it('should have 4 model configs', () => {
@@ -56,5 +56,22 @@ describe('getSearchConfig', () => {
   it('should return empty config for unknown model', () => {
     const config = getSearchConfig('unknown')
     expect(config).toEqual({})
+  })
+})
+
+describe('baseModel', () => {
+  it('should extract model key from instance key', () => {
+    expect(baseModel('gpt:0')).toBe('gpt')
+    expect(baseModel('gpt:1')).toBe('gpt')
+    expect(baseModel('claude:0')).toBe('claude')
+  })
+
+  it('should return the key as-is when no instance suffix', () => {
+    expect(baseModel('gpt')).toBe('gpt')
+    expect(baseModel('claude')).toBe('claude')
+  })
+
+  it('should handle edge cases', () => {
+    expect(baseModel('')).toBe('')
   })
 })

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -104,6 +104,12 @@ If tools or external checks are available, use them proactively.
   },
 }
 
+/** Extract the base model key from an instance key, e.g. 'gpt:1' → 'gpt' */
+export function baseModel(instanceKey: string): string {
+  const idx = instanceKey.indexOf(':')
+  return idx === -1 ? instanceKey : instanceKey.slice(0, idx)
+}
+
 export function getModelProvider(modelKey: string, apiKey?: string): LanguageModel {
   const config = MODEL_CONFIGS[modelKey]
   if (!config) throw new Error(`Unknown model: ${modelKey}`)


### PR DESCRIPTION
It seems the write permission is being blocked. Let me provide the plan directly as the PR body instead.

Here's the implementation plan for the draft PR:

---

Closes #16

## Problem

Users cannot request multiple responses from the same model. The system deduplicates models at multiple layers:
- **Review page** uses toggle selection (on/off per model) — no way to select "2x GPT"
- **URL params** pass `models=gpt,claude` — duplicates removed by `[...new Set(...)]` on line 67 of `conversation/page.tsx`
- **State** is `Record<string, ModelState>` keyed by model name — a second GPT response overwrites the first

## Approach

Introduce **instance keys** (`gpt:0`, `gpt:1`, `claude:0`) as a frontend-only concept that flows through URL params and React state. The backend only ever sees the base model key (`gpt`, `claude`). A helper function `baseModel(instanceKey)` extracts the model key for API calls and styling.

No database schema changes needed. No backend API changes needed.

## Planned Changes

- **`src/lib/models.ts`** — Add `baseModel(instanceKey: string): string` helper that splits `gpt:0` → `gpt`

- **`src/app/review/page.tsx`** — Counter UI instead of toggle
  - Change `selectedModels` from `string[]` to `Record<string, number>` (model key → count, default 1)
  - Replace toggle buttons with +/- counter controls per model (min 0, max 3)
  - Update `handleRun` to expand counts into instance keys: `{ gpt: 2, claude: 1 }` → `models=gpt:0,gpt:1,claude:0`

- **`src/app/conversation/page.tsx`** — Instance-keyed state
  - Remove `[...new Set(...)]` deduplication on line 67
  - Use instance keys as state dictionary keys: `round1States['gpt:0']`, `round1States['gpt:1']`
  - In `callModel` invocations, extract base model via `baseModel(instanceKey)` for the API call
  - Update rendering to derive display name and colors from `baseModel(instanceKey)`
  - Update TTS key to include instance key to avoid collisions between same-model cards
  - Update `retryModel` to use instance key for state but base model for API call

- **`src/app/conversation/[id]/page.tsx`** — No changes needed (already uses `r.id` as React key)
- **`src/app/api/conversation/respond/route.ts`** — No changes needed (receives base model key from frontend)
- **`src/app/api/conversation/route.ts`** — No changes needed (stores whatever models array the frontend sends)

## Test Strategy

- **Review page** — verify +/- controls, can select 2x GPT + 1x Claude, Run sends correct URL params
- **Conversation page** — verify N response cards appear with independent loading/error/response states
- **Round 2** — verify all instances get Round 2 calls
- **Retry** — retrying one GPT instance doesn't affect the other
- **TTS** — playing audio on one GPT card doesn't affect the other
- **Detail page** — refresh loads all responses from DB correctly
- **Regression** — selecting 1x of each model works identically to current behavior

## Risks / Open Questions

- **Max instances**: Capping at 3 per model to avoid API cost surprises. Could be configurable later.
- **DB backward compat**: Old conversations store `["gpt","claude"]` without instance suffixes. The detail page doesn't use the `models` JSON for rendering — it iterates the responses array — so old conversations display fine.
- **Cost awareness**: Each instance is a separate API call at full cost. The review page should show the total count so users understand they're requesting N separate responses.

---

Shall I create the draft PR with this plan, or would you like to adjust anything first?