### PR TITLE
model toggle

### DIFF
--- a/src/app/review/__tests__/page.test.tsx
+++ b/src/app/review/__tests__/page.test.tsx
@@ -93,12 +93,18 @@ describe('ReviewPage', () => {
     expect(hrefSpy).toHaveBeenCalledWith(expect.stringContaining('essayMode=true'))
   })
 
-  it('defaults each model count to 1 and sends instance keys', () => {
+  it('renders model cards as clickable toggles without +/- buttons', () => {
     render(<ReviewPage />)
-    // All 4 models should default to count 1
-    for (const key of ['claude', 'gpt', 'gemini', 'grok']) {
-      expect(screen.getByTestId(`count-${key}`)).toHaveTextContent('1')
-    }
+    // Model names should be visible
+    expect(screen.getByText('Claude')).toBeInTheDocument()
+    expect(screen.getByText('GPT')).toBeInTheDocument()
+    // No +/- buttons should exist
+    expect(screen.queryByLabelText(/increase/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/decrease/i)).not.toBeInTheDocument()
+  })
+
+  it('all models selected by default, sends instance keys in model:0 format', () => {
+    render(<ReviewPage />)
     fireEvent.click(screen.getByText('Run Conversation'))
     const url = hrefSpy.mock.calls[0]?.[0] as string
     const params = new URLSearchParams(url.split('?')[1])
@@ -109,50 +115,45 @@ describe('ReviewPage', () => {
     expect(models).toContain('grok:0')
   })
 
-  it('increases model count and generates multiple instance keys', () => {
+  it('clicking a model card toggles it off and excludes from URL', () => {
     render(<ReviewPage />)
-    // Click + for GPT twice to get count to 3
-    const increaseGpt = screen.getByLabelText('Increase GPT count')
-    fireEvent.click(increaseGpt)
-    fireEvent.click(increaseGpt)
-    expect(screen.getByTestId('count-gpt')).toHaveTextContent('3')
-
-    fireEvent.click(screen.getByText('Run Conversation'))
-    const url = hrefSpy.mock.calls[0]?.[0] as string
-    const params = new URLSearchParams(url.split('?')[1])
-    const models = params.get('models')?.split(',') ?? []
-    expect(models.filter(m => m.startsWith('gpt:'))).toHaveLength(3)
-    expect(models).toContain('gpt:0')
-    expect(models).toContain('gpt:1')
-    expect(models).toContain('gpt:2')
-  })
-
-  it('decreases model count to 0 and excludes from URL', () => {
-    render(<ReviewPage />)
-    const decreaseClaude = screen.getByLabelText('Decrease Claude count')
-    fireEvent.click(decreaseClaude)
-    expect(screen.getByTestId('count-claude')).toHaveTextContent('0')
+    // Click Claude card to deselect it
+    const claudeCard = screen.getByTestId('model-card-claude')
+    fireEvent.click(claudeCard)
 
     fireEvent.click(screen.getByText('Run Conversation'))
     const url = hrefSpy.mock.calls[0]?.[0] as string
     const params = new URLSearchParams(url.split('?')[1])
     const models = params.get('models')?.split(',') ?? []
     expect(models.filter(m => m.startsWith('claude:'))).toHaveLength(0)
+    expect(models).toContain('gpt:0')
   })
 
-  it('disables Run when all counts are 0', () => {
+  it('clicking a deselected model card toggles it back on', () => {
     render(<ReviewPage />)
-    // Set all to 0
-    for (const name of ['Claude', 'GPT', 'Gemini', 'Grok']) {
-      fireEvent.click(screen.getByLabelText(`Decrease ${name} count`))
+    const claudeCard = screen.getByTestId('model-card-claude')
+    // Toggle off then on
+    fireEvent.click(claudeCard)
+    fireEvent.click(claudeCard)
+
+    fireEvent.click(screen.getByText('Run Conversation'))
+    const url = hrefSpy.mock.calls[0]?.[0] as string
+    const params = new URLSearchParams(url.split('?')[1])
+    const models = params.get('models')?.split(',') ?? []
+    expect(models).toContain('claude:0')
+  })
+
+  it('disables Run when all models are deselected', () => {
+    render(<ReviewPage />)
+    for (const key of ['claude', 'gpt', 'gemini', 'grok']) {
+      fireEvent.click(screen.getByTestId(`model-card-${key}`))
     }
     expect(screen.getByText('Run Conversation')).toBeDisabled()
   })
 
-  it('shows total response count', () => {
+  it('does not show total response count', () => {
     render(<ReviewPage />)
-    // Default: 4 models × 1 = 4 total
-    expect(screen.getByText('4 responses total')).toBeInTheDocument()
+    expect(screen.queryByText(/responses total/i)).not.toBeInTheDocument()
   })
 
   it('deduplicates models when API returns duplicate providers', async () => {

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -34,9 +34,7 @@ function ReviewContent() {
 
   const [rawInput, setRawInput] = useState(initialRawInput)
   const [availableModels, setAvailableModels] = useState<string[]>(Object.keys(MODEL_CONFIGS))
-  const defaultCounts: Record<string, number> = {}
-  for (const key of Object.keys(MODEL_CONFIGS)) defaultCounts[key] = 1
-  const [modelCounts, setModelCounts] = useState<Record<string, number>>(defaultCounts)
+  const [selectedModels, setSelectedModels] = useState<string[]>(Object.keys(MODEL_CONFIGS))
 
   useEffect(() => {
     fetch('/api/user')
@@ -44,9 +42,7 @@ function ReviewContent() {
       .then(data => {
         if (data.subscriptionStatus === 'active') {
           setAvailableModels(Object.keys(MODEL_CONFIGS))
-          const counts: Record<string, number> = {}
-          for (const key of Object.keys(MODEL_CONFIGS)) counts[key] = 1
-          setModelCounts(counts)
+          setSelectedModels(Object.keys(MODEL_CONFIGS))
         } else if (data.providers?.length > 0) {
           const providerToModels: Record<string, string[]> = {}
           for (const [key, config] of Object.entries(MODEL_CONFIGS)) {
@@ -55,24 +51,17 @@ function ReviewContent() {
           }
           const available = [...new Set<string>(data.providers.flatMap((p: string) => providerToModels[p] || []))]
           setAvailableModels(available)
-          const counts: Record<string, number> = {}
-          for (const key of available) counts[key] = 1
-          setModelCounts(counts)
+          setSelectedModels(available)
         }
       })
       .catch(() => {})
   }, [])
 
-  const MAX_PER_MODEL = 3
-  const adjustCount = (key: string, delta: number) => {
-    setModelCounts((prev) => {
-      const current = prev[key] ?? 0
-      const next = Math.max(0, Math.min(MAX_PER_MODEL, current + delta))
-      return { ...prev, [key]: next }
-    })
+  const toggleModel = (key: string) => {
+    setSelectedModels((prev) =>
+      prev.includes(key) ? prev.filter((m) => m !== key) : [...prev, key]
+    )
   }
-
-  const totalSelected = Object.values(modelCounts).reduce((sum, n) => sum + n, 0)
 
   const augmentations: AugmentationsMap = useMemo(() => {
     try {
@@ -128,13 +117,7 @@ function ReviewContent() {
   }
 
   const handleRun = () => {
-    // Expand counts into instance keys: { gpt: 2, claude: 1 } → gpt:0,gpt:1,claude:0
-    const instanceKeys: string[] = []
-    for (const [key, count] of Object.entries(modelCounts)) {
-      for (let i = 0; i < count; i++) {
-        instanceKeys.push(`${key}:${i}`)
-      }
-    }
+    const instanceKeys = selectedModels.map((key) => `${key}:0`)
     const params = new URLSearchParams({
       rawInput,
       augmentedPrompt,
@@ -194,18 +177,20 @@ function ReviewContent() {
       <div className="animate-fade-up stagger-3 mb-6">
         <div className="flex items-center gap-3 mb-3">
           <p className="text-xs font-medium tracking-widest uppercase text-ink-faint">Panel</p>
-          <span className="text-xs text-ink-faint">{totalSelected} response{totalSelected !== 1 ? 's' : ''} total</span>
         </div>
         <div className="flex gap-2.5 flex-wrap">
           {Object.entries(MODEL_CONFIGS).map(([key, config]) => {
             const available = availableModels.includes(key)
-            const count = modelCounts[key] ?? 0
-            const active = available && count > 0
+            const active = available && selectedModels.includes(key)
             const colors = MODEL_COLORS[key] ?? { dot: 'bg-amber', activeBg: 'bg-amber-faint', activeBorder: 'border-amber/30', activeText: 'text-amber' }
             return (
               <div
                 key={key}
+                data-testid={`model-card-${key}`}
+                onClick={available ? () => toggleModel(key) : undefined}
                 className={`inline-flex items-center gap-2.5 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 border ${
+                  available ? 'cursor-pointer' : ''
+                } ${
                   !available
                     ? 'bg-cream-dark/20 border-border/50 text-ink-faint/40 opacity-50'
                     : active
@@ -218,27 +203,6 @@ function ReviewContent() {
                   <span>{config.name}</span>
                   <span className={`text-[10px] font-normal ${active ? 'opacity-60' : 'opacity-40'}`}>{config.modelId}</span>
                 </span>
-                {available && (
-                  <span className="inline-flex items-center gap-1 ml-1">
-                    <button
-                      aria-label={`Decrease ${config.name} count`}
-                      onClick={() => adjustCount(key, -1)}
-                      disabled={count <= 0}
-                      className="w-6 h-6 flex items-center justify-center rounded text-xs font-bold bg-card border border-border hover:border-border-strong disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer transition-colors"
-                    >
-                      −
-                    </button>
-                    <span className="w-5 text-center text-xs tabular-nums" data-testid={`count-${key}`}>{count}</span>
-                    <button
-                      aria-label={`Increase ${config.name} count`}
-                      onClick={() => adjustCount(key, 1)}
-                      disabled={count >= MAX_PER_MODEL}
-                      className="w-6 h-6 flex items-center justify-center rounded text-xs font-bold bg-card border border-border hover:border-border-strong disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer transition-colors"
-                    >
-                      +
-                    </button>
-                  </span>
-                )}
               </div>
             )
           })}
@@ -322,7 +286,7 @@ function ReviewContent() {
         </button>
         <button
           onClick={handleRun}
-          disabled={totalSelected === 0}
+          disabled={selectedModels.length === 0}
           className="flex-1 py-3 bg-amber text-white hover:bg-amber-light disabled:bg-cream-dark disabled:text-ink-faint rounded-xl font-medium transition-all duration-200 active:scale-[0.995]"
         >
           Run Conversation


### PR DESCRIPTION
Here's the implementation plan for the draft PR:

---

Closes #26

## Problem

PR #16 changed the model selection UI on the review page from simple toggle buttons (click to select/deselect, grayed out when not selected) to +/- counter controls. The user wants the original toggle behavior restored.

## Approach

Revert the review page's model selection UI from +/- counters back to clickable toggle buttons. Keep the instance key infrastructure from PR #16 intact — when a model is toggled on, it gets count=1 (producing a single `model:0` instance key). This preserves forward compatibility if multi-instance is re-introduced later, and avoids touching the conversation page at all.

The `baseModel()` helper in `models.ts` and the instance-key parsing in `conversation/page.tsx` remain unchanged — they already handle the `model:0` format correctly.

## Planned Changes

- **`src/app/review/page.tsx`**:
  - Remove `MAX_PER_MODEL` constant and `adjustCount()` function (lines 66-73)
  - Remove `totalSelected` derived value (line 75) and its display in the UI (line 197)
  - Replace `modelCounts` state (`Record<string, number>`) with `selectedModels` state (`Set<string>` or `string[]`) — toggled on/off per model, default all available models selected
  - Replace the +/- button group (lines 221-240) with a single click handler on the entire model card that toggles selection
  - Style: selected models get the active colored style, deselected models get the grayed-out style (existing `active`/inactive CSS already handles this)
  - Update `handleRun()` to expand `selectedModels` into instance keys: selected model `gpt` → `gpt:0`
  - Update the "Run Conversation" disabled check from `totalSelected === 0` to `selectedModels.length === 0`

No changes to:
- `src/lib/models.ts` — `baseModel()` still works
- `src/app/conversation/page.tsx` — still receives `model:0` format instance keys
- Any API routes or backend code

## Test Strategy

- **Manual**: Review page renders model cards as toggleable buttons. Clicking toggles between active (colored) and inactive (grayed out). Run button disabled when no models selected. URL params contain `gpt:0,claude:0,...` format.
- **Regression**: Conversation page renders correct number of response cards. Round 2, retry, TTS all work as before. Detail page (`/conversation/[id]`) loads correctly.

## Risks / Open Questions

- **Multi-instance removed from UI**: Users lose the ability to request multiple responses from the same model. The instance key plumbing remains in place, so re-adding this later (e.g., via a "power user" toggle or different UI) is straightforward.
- **No data migration needed**: The `model:0` instance key format is identical to what PR #16 produces for count=1, so existing conversations are unaffected.